### PR TITLE
Remove a trailing comma that was breaking 'npm install'

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dotenv": "^2.0.0",
     "express": "^4.13.3",
     "hbs": "~3.1.0",
-    "socket.io": "^1.4.5",
+    "socket.io": "^1.4.5"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
This fixes the `npm install` command.
